### PR TITLE
13.0 Fix delivery_postlogistics generate label handling error

### DIFF
--- a/delivery_postlogistics/postlogistics/web_service.py
+++ b/delivery_postlogistics/postlogistics/web_service.py
@@ -483,7 +483,12 @@ class PostlogisticsWebService(object):
             if response.status_code != 200:
                 res["success"] = False
                 res["errors"] = response.content.decode("utf-8")
-                return res
+                _logger.warning(
+                    "Shipping label could not be generated.\n"
+                    "Request: %s\n"
+                    "Response: %s" % (json.dumps(data), res["errors"])
+                )
+                return [res]
 
             response_dict = json.loads(response.content.decode("utf-8"))
 


### PR DESCRIPTION
The expected returned type is an array. This avoid the following error when a string is returned from `generate_label` 

`Traceback (most recent call last):
  File "/odoo/external-src/wms/shopfloor/services/service.py", line 75, in _dispatch_with_db_logging
    result = super().dispatch(method_name, *args, params=params)
  File "/odoo/external-src/rest-framework/base_rest/components/service.py", line 158, in dispatch
    res = method(*args, **secure_params)
  File "/odoo/external-src/rest-framework/base_rest/restapi.py", line 61, in response_wrap
    response = f(*args, **kw)
  File "/odoo/external-src/wms/shopfloor/services/checkout.py", line 1013, in done
    picking.action_done()
  File "/odoo/local-src/cosanum_report/models/stock_picking.py", line 224, in action_done
    res = super().action_done()
  File "/odoo/external-src/odoo-shopinvader/shopinvader_delivery_carrier/models/stock_picking.py", line 61, in action_done
    result = super(StockPicking, self).action_done()
  File "/odoo/local-src/delivery_brauch/models/stock_picking.py", line 105, in action_done
    return super().action_done()
  File "/odoo/external-src/account-invoicing/account_invoice_mode_at_shipping/models/stock_picking.py", line 13, in action_done
    res = super().action_done()
  File "/odoo/src/addons/mrp_subcontracting/models/stock_picking.py", line 41, in action_done
    res = super(StockPicking, self).action_done()
  File "/odoo/src/addons/stock/models/stock_picking.py", line 732, in action_done
    self._send_confirmation_email()
  File "/odoo/src/addons/delivery/models/stock_picking.py", line 128, in _send_confirmation_email
    pick.send_to_shipper()
  File "/odoo/src/addons/delivery/models/stock_picking.py", line 169, in send_to_shipper
    res = self.carrier_id.send_shipping(self)[0]
  File "/odoo/external-src/delivery-carrier/delivery_carrier_pricelist/models/delivery_carrier.py", line 47, in send_shipping
    result = super().send_shipping(pickings)
  File "/odoo/src/addons/delivery/models/delivery_carrier.py", line 174, in send_shipping
    return getattr(self, '%s_send_shipping' % self.delivery_type)(pickings)
  File "/odoo/external-src/delivery-carrier/delivery_postlogistics/models/delivery_carrier.py", line 131, in postlogistics_send_shipping
    pick._generate_postlogistics_label()
  File "/odoo/local-src/cosanum_delivery_postlogistics/models/stock_picking.py", line 18, in _generate_postlogistics_label
    package_ids=package_ids,
  File "/odoo/external-src/delivery-carrier/delivery_postlogistics/models/stock_picking.py", line 213, in _generate_postlogistics_label
    labels = self.write_tracking_number_label(success_label_results, packages)
  File "/odoo/local-src/cosanum_delivery_postlogistics/models/stock_picking.py", line 24, in write_tracking_number_label
    for label_value in label['value']:
TypeError: string indices must be integers`

Also the request and response error are logged.